### PR TITLE
Feature/delete customer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ API para gerenciar os produtos favoritos dos clientes.
 - Buscar clientes
 - Buscar cliente por id
 - Atualizar cliente
+- Excluir cliente
 </details>
 
 ---

--- a/src/module/customer/application/service/customer.service.spec.ts
+++ b/src/module/customer/application/service/customer.service.spec.ts
@@ -23,6 +23,7 @@ describe('CustomerService', () => {
             findOneById: jest.fn(),
             findAll: jest.fn(),
             update: jest.fn(),
+            delete: jest.fn(),
           },
         },
       ],
@@ -165,6 +166,36 @@ describe('CustomerService', () => {
       expect(customerRepository.update).toHaveBeenCalledWith(
         expect.objectContaining({ name: dto.name, email: dto.email }),
       );
+    });
+  });
+
+  describe('delete', () => {
+    it('should not delete a customer if not exists', async () => {
+      const id = '123';
+
+      (customerRepository.findOneById as jest.Mock).mockResolvedValue(null);
+
+      await expect(customerService.delete(id)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('should delete a customer', async () => {
+      const id = '123';
+
+      const customer = new CustomerEntity({
+        id,
+        name: 'John Doe',
+        email: 'johndoe@email.com',
+      });
+
+      (customerRepository.findOneById as jest.Mock).mockResolvedValue({
+        customer,
+      });
+
+      await customerService.delete(id);
+
+      expect(customerRepository.delete).toHaveBeenCalledWith(id);
     });
   });
 });

--- a/src/module/customer/application/service/customer.service.ts
+++ b/src/module/customer/application/service/customer.service.ts
@@ -54,4 +54,12 @@ export class CustomerService {
 
     await this.repository.update(customer);
   }
+
+  async delete(id: string): Promise<void> {
+    const hasCustomer = await this.repository.findOneById(id);
+
+    if (!hasCustomer) throw new BadRequestException('Customer not found');
+
+    await this.repository.delete(id);
+  }
 }

--- a/src/module/customer/domain/repository/customer.repository.ts
+++ b/src/module/customer/domain/repository/customer.repository.ts
@@ -6,4 +6,5 @@ export interface ICustomerRepository {
   findOneById(id: string): Promise<CustomerEntity>;
   findAll(): Promise<CustomerEntity[]>;
   update(customer: CustomerEntity): Promise<void>;
+  delete(id: string): Promise<void>;
 }

--- a/src/module/customer/infra/database/repository/typeorm.customer.repository.integration.spec.ts
+++ b/src/module/customer/infra/database/repository/typeorm.customer.repository.integration.spec.ts
@@ -207,4 +207,35 @@ describe('TypeOrmCustomerRepository (integration)', () => {
     });
   });
 
+  describe('delete', () => {
+    it('should delete a customer', async () => {
+      const now = new Date();
+      const id = '1';
+
+      const customer = new CustomerEntity({
+        id,
+        name: 'John Doe',
+        email: 'johndoe@email.com',
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      await typeOrmRepository.save(typeOrmRepository.create({
+        id: customer.id,
+        name: customer.name,
+        email: customer.email,
+        createdAt: customer.createdAt,
+        updatedAt: customer.updatedAt
+      }));
+
+       const oldCustomer = await customerRepository.findOneById(id);
+       expect(oldCustomer.name).toBe(customer.name);
+       expect(oldCustomer.email).toBe(customer.email);
+
+      await customerRepository.delete(id);
+
+      const newCustomer = await customerRepository.findOneById(id);
+      expect(newCustomer).toBeNull();
+    });
+  });
 });

--- a/src/module/customer/infra/database/repository/typeorm.customer.repository.ts
+++ b/src/module/customer/infra/database/repository/typeorm.customer.repository.ts
@@ -34,9 +34,13 @@ export class TypeOrmCustomerRepository implements ICustomerRepository {
     return TypeOrmCustomerMapper.toEntityList(models);
   }
 
-    async update(customer: CustomerEntity): Promise<void> {
+  async update(customer: CustomerEntity): Promise<void> {
     const model = TypeOrmCustomerMapper.toModel(customer);
 
     await this.repository.save(model);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repository.delete(id);
   }
 }

--- a/src/module/customer/infra/http/controller/customer.controller.e2e.spec.ts
+++ b/src/module/customer/infra/http/controller/customer.controller.e2e.spec.ts
@@ -157,4 +157,23 @@ describe('CustomerController (e2e)', () => {
       );
     });
   });
+
+  describe('delete', () => {
+    it('/customers/:id (DELETE) - should delete a customer', async () => {
+      const id = uuid();
+
+      await customerRepository.save({
+        id,
+        name: 'John Doe',
+        email: 'john@example.com',
+      });
+
+      const spyService = jest.spyOn(service, 'delete');
+
+      await request(app.getHttpServer()).delete(`/customers/${id}`).expect(200);
+
+      expect(spyService).toHaveBeenCalledTimes(1);
+      expect(spyService).toHaveBeenCalledWith(expect.any(String));
+    });
+  });
 });

--- a/src/module/customer/infra/http/controller/customer.controller.ts
+++ b/src/module/customer/infra/http/controller/customer.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { CustomerService } from '../../../application/service/customer.service';
 import {
   ApiBadRequestResponse,
@@ -76,5 +84,19 @@ export class CustomerController {
     @Body() dto: UpdateCustomerRequest,
   ): Promise<void> {
     return this.service.update(id, dto);
+  }
+
+  @ApiOperation({ summary: 'Delete customer by id' })
+  @ApiResponse({
+    status: 200,
+    description: 'Customer deleted',
+  })
+  @ApiBadRequestResponse({
+    description: 'Some data is invalid',
+    type: DefaultErrorResponse,
+  })
+  @Delete(':id')
+  async delete(@Param('id') id: string): Promise<void> {
+    return this.service.delete(id);
   }
 }


### PR DESCRIPTION
# [FEATURE] Delete Customer - Favorites API

## 📌 Contexto
Esta PR implementa a funcionalidade de **excluir cliente** na API.  

**Principais requisitos atendidos:**
- Endpoint para excluir cliente
- Testes unitários e de integração

---

## 🛠 Alterações realizadas
- Endpoint `DELETE/customers/:id`


## **Testes**
- Testes unitários e de integração
<img width="187" height="75" alt="image" src="https://github.com/user-attachments/assets/8a2d1b10-ce21-4c4a-bce6-24f5709832b4" />

**Cenário de testes (Gherkin)**
- Cenário 1: Não excluir cliente
Dado que o cliente não esteja cadastrado
Quando excluir o cliente
Então será retornado um erro
E com status 400

- Cenário 2: Excluir cliente
Dado que o cliente esteja cadastrado
Quando excluir o cliente
Então os dados serão removidos
E com status 200

**Documentação**
- Swagger/OpenAPI atualizado com endpoint  `DELETE/customers/:id`
- Exemplos de request/response
- README atualizado com instruções de setup e uso da feature

Exemplo de request
```bash
curl -X DELETEhttp://localhost:3000/api/customers/:id\
-H "Content-Type: application/json" \
```
---

## ⚡ Como testar localmente
```bash
# Instalar dependências
npm install

# Iniciar servidor
npm run start:dev

# Testes
npm run test
